### PR TITLE
Add rating system to car deal scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Scrape and analyze car listings from dealership websites with stealth and human-
 - Random mouse movements and keypresses
 - Bypasses basic bot detection
 - Supports most car dealership websites
-- Outputs clean listing titles, prices, and links
+- Outputs clean listing titles, prices, links, and a color-coded deal rating
+
+Listings are rated based on their price relative to the page average:
+**green** indicates a great deal, **yellow** is around average, and **red**
+means the price is above average.
 
 ## How to Use
 1. Extract ZIP file.

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,18 @@
             width: 60%;
             text-align: left;
         }
+        .green { background-color: #d4edda; }
+        .yellow { background-color: #fff3cd; }
+        .red { background-color: #f8d7da; }
     </style>
 </head>
 <body>
     <h1>Universal Car Deal Rater 🚗</h1>
+    <p>
+        <span style="background:#d4edda;padding:3px 6px;">Green</span> good deal,
+        <span style="background:#fff3cd;padding:3px 6px;">Yellow</span> fair,
+        <span style="background:#f8d7da;padding:3px 6px;">Red</span> overpriced
+    </p>
     <input id="urlInput" type="text" placeholder="Enter Car Listing Page URL" />
     <br>
     <button onclick="scrape()">Scrape Listings</button>
@@ -53,8 +61,8 @@
             if (data.listings) {
                 data.listings.forEach(car => {
                     const carDiv = document.createElement('div');
-                    carDiv.className = 'listing';
-                    carDiv.innerHTML = `<strong>${car.title}</strong><br>Price: ${car.price}<br><a href="${car.link}" target="_blank">View Listing</a>`;
+                    carDiv.className = `listing ${car.rating}`;
+                    carDiv.innerHTML = `<strong>${car.title}</strong><br>Price: ${car.price}<br>Rating: ${car.rating} - ${car.reason}<br><a href="${car.link}" target="_blank">View Listing</a>`;
                     resultsDiv.appendChild(carDiv);
                 });
             } else {


### PR DESCRIPTION
## Summary
- parse prices as numbers in backend
- compute price averages and assign green/yellow/red ratings with reasons
- color-code listing results on the frontend and show rating explanations
- document rating criteria in the README

## Testing
- `npm install`
- `node -c app.js`
- `npm start --silent` (terminated after verifying startup)

------
https://chatgpt.com/codex/tasks/task_e_6846304d61fc83239f9224c92697c7a1