### PR TITLE
Add Jest test for /scrape endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/app.js
+++ b/app.js
@@ -1,6 +1,15 @@
 const express = require('express');
-const puppeteer = require('puppeteer-extra');
-const StealthPlugin = require('puppeteer-extra-plugin-stealth');
+let puppeteer;
+let StealthPlugin;
+
+function initPuppeteer() {
+    if (!puppeteer) {
+        puppeteer = require('puppeteer-extra');
+        StealthPlugin = require('puppeteer-extra-plugin-stealth');
+        puppeteer.use(StealthPlugin());
+    }
+    return puppeteer;
+}
 const path = require('path');
 
 // Helper to parse price text like "$25,000" to a number (25000)
@@ -9,7 +18,6 @@ function parsePrice(text) {
     return isNaN(num) ? 0 : num;
 }
 
-puppeteer.use(StealthPlugin());
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -34,6 +42,7 @@ app.post('/scrape', async (req, res) => {
 
     try {
         console.log(`Navigating to ${url}...`);
+        const puppeteer = initPuppeteer();
         browser = await puppeteer.launch({
             headless: false,
             slowMo: 50,
@@ -89,4 +98,8 @@ app.post('/scrape', async (req, res) => {
     }
 });
 
-app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+if (require.main === module) {
+    app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "Universal Car Listing Scraper with Smart Stealth & Human Simulation",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
+    "puppeteer": "^22.8.2",
     "puppeteer-extra": "^3.3.5",
-    "puppeteer-extra-plugin-stealth": "^2.11.1",
-    "puppeteer": "^22.8.2"
+    "puppeteer-extra-plugin-stealth": "^2.11.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2",
+    "supertest": "^7.1.1"
   }
 }

--- a/tests/scrape.test.js
+++ b/tests/scrape.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /scrape', () => {
+  test('should return 400 when body is missing', async () => {
+    const res = await request(app).post('/scrape');
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
- add dev dependencies `jest` and `supertest`
- export the express app and lazy-load puppeteer so tests work without puppeteer installed
- add `.gitignore`
- test `/scrape` endpoint for missing body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684631cde8048323b3794b2b1437385f