### PR TITLE
Fix missing helpers causing crashes

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,31 @@ function parsePrice(text) {
     return isNaN(num) ? 0 : num;
 }
 
+// Simple promise-based delay helper
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Try scraping listings using a specific set of selectors
+async function scrapeWithSelectors(page, selectors) {
+    try {
+        return await page.$$eval(selectors.container, (nodes, sel) => {
+            return nodes.map(node => {
+                const titleEl = node.querySelector(sel.title);
+                const priceEl = node.querySelector(sel.price);
+                const linkEl = node.querySelector('a');
+                return {
+                    title: titleEl ? titleEl.textContent.trim() : '',
+                    price: priceEl ? priceEl.textContent.trim() : '',
+                    link: linkEl ? linkEl.href : ''
+                };
+            });
+        }, selectors);
+    } catch (err) {
+        return [];
+    }
+}
+
 
 
 const app = express();

--- a/tests/scrape.test.js
+++ b/tests/scrape.test.js
@@ -1,10 +1,42 @@
 const request = require('supertest');
 const app = require('../app');
 
+jest.setTimeout(30000);
+
+let server;
+
+beforeAll(done => {
+  const http = require('http');
+  server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`
+      <div class="listing">
+        <span class="title">Test Car</span>
+        <span class="price">$9999</span>
+        <a href="http://example.com">link</a>
+      </div>
+    `);
+  }).listen(5000, done);
+});
+
+afterAll(done => {
+  server.close(done);
+});
+
 describe('POST /scrape', () => {
   test('should return 400 when body is missing', async () => {
     const res = await request(app).post('/scrape');
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty('error');
+  });
+
+  test('should scrape listings from a local page', async () => {
+    const res = await request(app)
+      .post('/scrape')
+      .send({ url: 'http://localhost:5000' });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.listings)).toBe(true);
+    expect(res.body.listings.length).toBeGreaterThan(0);
+    expect(res.body.listings[0].title).toContain('Test Car');
   });
 });


### PR DESCRIPTION
## Summary
- define `delay` and `scrapeWithSelectors` helpers used by `/scrape`
- add integration test for scraping a local page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68463954974c8323b19a58eeea41d6a2